### PR TITLE
Changed deprecated iOS8 RSSI CoreBluetooth call.

### DIFF
--- a/LGBluetooth/LGCentralManager.m
+++ b/LGBluetooth/LGCentralManager.m
@@ -267,7 +267,8 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         LGPeripheral *lgPeripheral = [self wrapperByPeripheral:peripheral];
         [lgPeripheral handleDisconnectWithError:error];
-        [self.scannedPeripherals removeObject:lgPeripheral];
+        // Allow rapid connection/disconnection/connection as per: https://github.com/l0gg3r/LGBluetooth/issues/6
+        //[self.scannedPeripherals removeObject:lgPeripheral];
     });
 }
 

--- a/LGBluetooth/LGPeripheral.m
+++ b/LGBluetooth/LGPeripheral.m
@@ -297,11 +297,11 @@ NSString * const kConnectionMissingErrorMessage = @"BLE Device is not connected"
     });
 }
 
-- (void)peripheralDidUpdateRSSI:(CBPeripheral *)peripheral error:(NSError *)error
+- (void)peripheral:(CBPeripheral *)peripheral didReadRSSI:(NSNumber *)RSSI error:(NSError *)error
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (self.rssiValueBlock) {
-            self.rssiValueBlock(peripheral.RSSI, error);
+            self.rssiValueBlock(RSSI, error);
         }
         self.rssiValueBlock = nil;
     });


### PR DESCRIPTION
Changed deprecated iOS8 RSSI CoreBluetooth call.

peripheral.RSSI and peripheralDidUpdateRSSI were deprecated in iOS8 - now need to use the didReadRSSI API.
